### PR TITLE
Xi Rework Pylon Fix

### DIFF
--- a/Assets/StreamingAssets/Sectors/main - 0.0.0/CoreScripts/BattleZone Xi.corescript
+++ b/Assets/StreamingAssets/Sectors/main - 0.0.0/CoreScripts/BattleZone Xi.corescript
@@ -14,6 +14,7 @@ SectorTrigger(
                     Call(BZXiDefectedCarrier1DeathHelper),
                     Call(BZXiDefectedBase1DeathHelper),
                     Call(BZXiPostVictoryDialogue),
+                    Call(Legend_spawnPylon2),
                     ConditionBlock(
                         DestroyEntities(
                             targetID=BZXiDefectedCommander1,


### PR DESCRIPTION
That single line of code missing to force the Pylon for Xi to spawn in a won/occupied state of the sector. Sorry that took me so long.